### PR TITLE
Fixed fmt-cpu-temp in contrib/cpu.lisp

### DIFF
--- a/mode-line.lisp
+++ b/mode-line.lisp
@@ -33,7 +33,8 @@
           add-screen-mode-line-formatter
 	  enable-mode-line
 	  toggle-mode-line
-	  bar-zone-color))
+	  bar-zone-color
+      bar))
 
 (defstruct mode-line
   screen


### PR DESCRIPTION
Now function can determine what type of interface
(old /proc or a new /sys) is used
